### PR TITLE
Update Line and Algo omission description

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ which will be displayed like this
 
 Note that **L0** and **L1** are the same identifiers in each row corresponding to a line whereas **A0** is the algorithm identifier and determines the coloring of the lines (in this case, only 1 color is needed).
 
-If the attributes **line** and **algo** are missing they will be added to the dataset on the fly and filled with default values.
+If the attributes **line** and **algo** are omitted, the data is projected as points without lines.
 
 
 ### Additional Columns


### PR DESCRIPTION
Hi!

Instead of 
> If the attributes **line** and **algo** are missing they will be added to the dataset on the fly and filled with default values.

I suggest the following text (as i was unsure what the defaults are 🙂  ):
> If the attributes **line** and **algo** are omitted, the data is projected as points without lines. 

---


I've tested with this CSV:
```
x,y
0.0,0
2.0,1
4.0,4
6.0,1
8.0,0
12.0,0
-1.0,10
0.5,5
2.0,3
3.5,0
5.0,3
6.5,5
8.0,10
3.0,6
2.0,7
```

and the projeciton looks like this:
![image](https://user-images.githubusercontent.com/10337788/95718535-e2722780-0c6e-11eb-929f-132bc6ab9425.png)



Test on https://develop--projection-path-explorer.netlify.app/