### PR TITLE
Rename brightness to opacity

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Additional columns might exist in the source file. If this is the case the tool 
 Possible visualization properties that can be changed are:
 
  - **color** (by categorical and sequential/diverging attributes)
- - **brightness** (by sequential/diverging attributes)
+ - **opacity** (by sequential/diverging attributes)
  - **transparency** (by sequential/diverging attributes)
  - **size** (by sequential/diverging attributes)
 

--- a/src/components/DrawerTabPanels/StatesTabPanel/BrightnessSlider.tsx
+++ b/src/components/DrawerTabPanels/StatesTabPanel/BrightnessSlider.tsx
@@ -21,29 +21,29 @@ const BrightnessSliderFull = ({ brightnessScale, setRange }) => {
     const marks = [
         {
             value: 0,
-            label: '0',
+            label: '0%',
         },
         {
             value: 0.25,
-            label: `0.25`,
+            label: `25%`,
         },
         {
             value: 0.5,
-            label: `0.5`,
+            label: `50%`,
         },
         {
             value: 0.75,
-            label: `0.75`,
+            label: `75%`,
         },
         {
             value: 1,
-            label: `1`,
+            label: `100%`,
         }
     ];
 
     return <div className={classes.root}>
         <Typography id="range-slider" gutterBottom>
-            Brightness Scale
+            Opacity Scale
         </Typography>
         <Slider
             min={0}

--- a/src/components/DrawerTabPanels/StatesTabPanel/StatesTabPanel.tsx
+++ b/src/components/DrawerTabPanels/StatesTabPanel/StatesTabPanel.tsx
@@ -188,7 +188,7 @@ export const StatesTabPanelFull = ({
         {
             categoryOptions != null && CategoryOptionsAPI.hasCategory(categoryOptions, "transparency") ?
 
-                <SelectFeatureComponent label={"brightness"} default_val={channelBrightness} categoryOptions={CategoryOptionsAPI.getCategory(categoryOptions, "transparency")} onChange={(newValue) => {
+                <SelectFeatureComponent label={"opacity"} default_val={channelBrightness} categoryOptions={CategoryOptionsAPI.getCategory(categoryOptions, "transparency")} onChange={(newValue) => {
                     var attribute = CategoryOptionsAPI.getCategory(categoryOptions, "transparency").attributes.filter(a => a.key == newValue)[0]
 
                     if (attribute == undefined) {


### PR DESCRIPTION


Rename brightness in Encoding menu pane to opacity to be more specific.
![image](https://user-images.githubusercontent.com/10337788/148770389-3940e132-d428-468f-aaef-e642aae04a82.png)


Currently, more brightness (100%) is more opaque, which is misleading anyway.