### PR TITLE
Change color of contour lines to grey

### DIFF
--- a/src/components/WebGLView/MultivariateClustering.tsx
+++ b/src/components/WebGLView/MultivariateClustering.tsx
@@ -19,6 +19,7 @@ import { AStorytelling } from "../Ducks/StoriesDuck";
 import TessyWorker from '../workers/tessy.worker';
 import { ViewTransformType } from "../Ducks";
 import { BaseColorScale } from "../Ducks/ColorScalesDuck";
+import { SchemeColor } from "..";
 
 
 const SELECTED_COLOR = 0x007dad
@@ -391,7 +392,7 @@ export const MultivariateClustering = connector(class extends React.Component<Pr
                 mesh: circle,
                 children: [],
                 trailPositions: [],
-                lineColor: ScaleUtil.mapScale(scale, scaleI),//for paper used: new SchemeColor(DEFAULT_COLOR),
+                lineColor: new SchemeColor(DEFAULT_COLOR),
                 triangulatedMesh: {
 
                 },


### PR DESCRIPTION

Contour line colors are not related to point colors (unless you use clustering):
![image](https://user-images.githubusercontent.com/10337788/148771550-3bb8f2d3-b490-4f6b-80cb-a460a9122843.png)

I've set them to grey (default color):
![image](https://user-images.githubusercontent.com/10337788/148771670-96416bd4-0407-4e11-9a74-22a7ff933f92.png)

It should still be easy to determine which group it belongs to.
